### PR TITLE
Add manual trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag name for release'
+        required: true
 
 jobs:
   build:
@@ -40,6 +45,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: SprachsteuerungApp.zip
-          name: Release ${{ github.ref_name }}
-          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 


### PR DESCRIPTION
## Summary
- allow manual invocation of release workflow via `workflow_dispatch`
- conditionally set release tag and name based on manual inputs

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685176ab102083328cb94929581eee63